### PR TITLE
[Feature] Endpoint to display labels

### DIFF
--- a/app/Http/Controllers/MainController.php
+++ b/app/Http/Controllers/MainController.php
@@ -87,4 +87,11 @@ class MainController extends Controller
             'issues' => $label->issues()->orderBy('original_created_at', 'desc')->paginate(20)
         ]);
     }
+
+    function labelsAll()
+    {
+        return view('labels', [
+            'labels' => Label::all()
+        ]);
+    }
 }

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -217,3 +217,26 @@ ul.pagination li {
 	color: #1D2C4E;
 	padding: 6px 10px;
 }
+
+.labels {
+	padding: 0px 40px;
+}
+
+.labels ul li {
+	border-bottom: 0px;
+	padding: 6px 10px;
+	display: inline-flex;
+}
+
+.labels ul li a {
+	background-color: #FFF922;
+	color: #000;
+	padding: 6px 10px;
+	text-decoration: none;
+}
+
+.labels ul li a:hover {
+	background-color: #FF00AA;
+	color: #000;
+	padding: 6px 10px;
+}

--- a/resources/views/labels.blade.php
+++ b/resources/views/labels.blade.php
@@ -1,0 +1,16 @@
+@extends('main')
+
+@section('content')
+    <div class="header">
+        <h2>Issues by Label</h2>
+    </div>
+
+    <div class="labels">
+        <ul>	
+            @foreach ($labels as $label)	
+                <li><a href="{{ route('label.list', $label->name) }}" title="View {{ $label->name }} Issues">{{ $label->name }}</a></li>	
+            @endforeach	
+        </ul>	
+    </div>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,3 +17,5 @@ Route::get('/', 'MainController@main');
 Route::get('/b/{language}', 'MainController@languageBoard')->name('board.list');
 
 Route::get('/l/{label_name}', 'MainController@labelBoard')->name('label.list');
+
+Route::get('/l', 'MainController@labelsAll')->name('labels.all');


### PR DESCRIPTION
Addresses: https://github.com/erikaheidi/hacktober-board/issues/2

This introduces a new endpoint at `http://127.0.0.1:8000/l` which renders all of the labels. I stole some of the styles from other parts of the site, let me know what you think.

No Hover:
![Screen Shot 2019-10-06 at 9 48 58 PM](https://user-images.githubusercontent.com/2836589/66280144-4d7e6680-e883-11e9-8066-4bff71d3d04f.png)

Hover:
![Screen Shot 2019-10-06 at 9 49 04 PM](https://user-images.githubusercontent.com/2836589/66280146-51aa8400-e883-11e9-93f2-a5446454c053.png)