### PR TITLE
Special character in labels & languages are not escaped

### DIFF
--- a/resources/views/board.blade.php
+++ b/resources/views/board.blade.php
@@ -26,7 +26,7 @@
 
                 <div class="tags">
                     @foreach ($issue->labels as $label)
-                        <span class="tag"><a href="{{ route('label.list', $label->name) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
+                        <span class="tag"><a href="{{ route('label.list', urlencode($label->name)) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
                     @endforeach
                 </div>
             </li>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -9,7 +9,7 @@
     @foreach ($newest_issues as $issue)
         <div class="box">
             <div class="title">
-               @if ($issue->project_language) <div class="issue-number"><a href="{{ route('board.list', $issue->project_language) }}" class="highlight">{{ $issue->project_language }}</a></div> @endif
+               @if ($issue->project_language) <div class="issue-number"><a href="{{ route('board.list', urlencode($issue->project_language)) }}" class="highlight">{{ $issue->project_language }}</a></div> @endif
                 <a href="{{ $issue->project->html_url }}">{{ $issue->project->full_name }}</a> {{ $issue->created_at->diffForHumans() }}</div>
             <ul>
                 <li>
@@ -26,7 +26,7 @@
 
                     <div class="tags">
                         @foreach ($issue->labels as $label)
-                            <span class="tag"><a href="{{ route('label.list', $label->name) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
+                            <span class="tag"><a href="{{ route('label.list', urlencode($label->name)) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
                         @endforeach
                     </div>
                 </li>
@@ -40,7 +40,7 @@
 
     @foreach ($boards as $board)
     <div class="box">
-        <div class="title"><a href="{{ route('board.list', $board['language']) }}">{{ $board['language'] }}</a></div>
+        <div class="title"><a href="{{ route('board.list', urlencode($board['language'])) }}">{{ $board['language'] }}</a></div>
         <ul>
             @each('issue', $board['issues'], 'issue')
         </ul>
@@ -53,7 +53,7 @@
 
     @foreach ($second_level_boards as $board)
         <div class="box">
-            <div class="title"><a href="{{ route('label.list', $board['label']) }}" title="See more Issues with this Label">{{ $board['label'] }}</a></div>
+            <div class="title"><a href="{{ route('label.list', urlencode($board['label'])) }}" title="See more Issues with this Label">{{ $board['label'] }}</a></div>
             <ul>
                 @each('issue', $board['issues'], 'issue')
             </ul>

--- a/resources/views/issue.blade.php
+++ b/resources/views/issue.blade.php
@@ -11,7 +11,7 @@
                 <a href="{{ $issue->html_url }}" title="Visit the Issue Page for more Info" target="_blank">{{ $issue->title }}</a>
             </div>
 
-        @if ($issue->project_language) <div class="issue-language"><a href="{{ route('board.list', $issue->project_language) }}">{{ $issue->project_language }}</a></div> @endif
+        @if ($issue->project_language) <div class="issue-language"><a href="{{ route('board.list', urlencode($issue->project_language)) }}">{{ $issue->project_language }}</a></div> @endif
 
             <div class="repo-name"><a href="{{ $issue->project->html_url }}" title="Visit the project page on Github" target="_blank">{{ $issue->project->full_name }}</a> {{ $issue->created_at->diffForHumans() }}</div>
 
@@ -20,7 +20,7 @@
 
     <div class="tags">
         @foreach ($issue->labels as $label)
-            <span class="tag"><a href="{{ route('label.list', $label->name) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
+            <span class="tag"><a href="{{ route('label.list', urlencode($label->name)) }}" title="See more Issues with this Label">{{ $label->name }}</a></span>
         @endforeach
     </div>
 

--- a/resources/views/labels.blade.php
+++ b/resources/views/labels.blade.php
@@ -6,11 +6,11 @@
     </div>
 
     <div class="labels">
-        <ul>	
-            @foreach ($labels as $label)	
-                <li><a href="{{ route('label.list', $label->name) }}" title="View {{ $label->name }} Issues">{{ $label->name }}</a></li>	
-            @endforeach	
-        </ul>	
+        <ul>
+            @foreach ($labels as $label)
+                <li><a href="{{ route('label.list', urlencode($label->name)) }}" title="View {{ $label->name }} Issues">{{ $label->name }}</a></li>
+            @endforeach
+        </ul>
     </div>
 
 @endsection

--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -42,7 +42,7 @@
         <ul>
             @foreach ($all_languages as $project)
                 @if ($project->language)
-                    <li><a href="{{ route('board.list', $project->language) }}" title="View {{ $project->language }} Issues">{{ $project->language }}</a></li>
+                    <li><a href="{{ route('board.list', urlencode($project->language)) }}" title="View {{ $project->language }} Issues">{{ $project->language }}</a></li>
                 @endif
             @endforeach
         </ul>


### PR DESCRIPTION
As an example, C# in the language list cannot be accessed and is understood as `c` currently since the `#` character is not urlencoded (should be `%23`).

This is a small pull request to fix this and allow viewing of the C# language without having me hacking the url 😁