### PR TITLE
Fixes for docker image and container build - Issue #31

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 ...
 .gitignore
 .env
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,19 +44,15 @@ USER composer
 # Run Composer Install
 RUN /usr/local/bin/composer install
 
+# Change current user to www
+USER www-data
+
 # Since .env is in .dockerignore, we have to get it from somewhere
 RUN cp .env.example .env
 
 # Generate App Key
-#RUN php artisan key:generate
+RUN php artisan key:generate
 
-# Migrate the DB
-#RUN php artisan migrate
-
-# Seed the Table
-#RUN php artisan db:seed
-
-# Change current user to www, expose port 8000 and start php-fpm server
-USER www-data
+# Expose port 8000 and start php-fpm server
 EXPOSE 8000
 CMD ["php-fpm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM php:7.2-fpm
 RUN apt-get update && apt-get install -y \
     git \
     curl \
-    libpng-dev
+    libpng-dev \
+    zip \
+    unzip
 
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -27,6 +29,12 @@ RUN useradd -ms /bin/bash composer
 # Copy existing application directory permissions
 COPY --chown=www-data:composer . /var/www
 
+# Directory is initially owned by root:root. Change it so composer will be able to write
+RUN chown www-data:composer /var/www
+
+# Make the directory's group permissions match the owner permissions
+RUN chmod g=u /var/www
+
 # Set working directory
 WORKDIR /var/www
 
@@ -36,8 +44,11 @@ USER composer
 # Run Composer Install
 RUN /usr/local/bin/composer install
 
+# Since .env is in .dockerignore, we have to get it from somewhere
+RUN cp .env.example .env
+
 # Generate App Key
-RUN php artisan key:generate
+#RUN php artisan key:generate
 
 # Migrate the DB
 #RUN php artisan migrate
@@ -45,9 +56,7 @@ RUN php artisan key:generate
 # Seed the Table
 #RUN php artisan db:seed
 
-# Change current user to www
+# Change current user to www, expose port 8000 and start php-fpm server
 USER www-data
-
-# Expose port 8000 and start php-fpm server
 EXPOSE 8000
 CMD ["php-fpm"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     working_dir: /var/www/
     networks:
       - hacktober
+    volumes:
+      # Mount the entire codebase, minus paths in .dockerignore
+      - ./:/var/www
+      # Mount empty volume to the image's vendor directory so we don't overwrite it
+      - vendor:/var/www/vendor
 
   db:
     image: mysql:5.7.22
@@ -40,3 +45,7 @@ services:
 networks:
   hacktober:
     driver: bridge
+
+# Specify the named volumes used above
+volumes:
+  vendor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     working_dir: /var/www/
     networks:
       - hacktober
-    volumes:
-      - ./:/var/www
 
   db:
     image: mysql:5.7.22

--- a/readme.md
+++ b/readme.md
@@ -11,22 +11,37 @@ A Docker dev environment is included. You'll need **Docker** and **Docker Compos
 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+### Fork and Clone
+
+If you are planning to contribute, you will need to:
+1) fork this repository in GitHub
+1) create a local clone of your fork.
+
+If you're not familiar with this process, [click here for the really detailed version](https://help.github.com/en/github/getting-started-with-github/fork-a-repo).
+
+If you're not planning to contribute and just want to play with hacktober-board in a local dev environment, you can simply clone this repo
+
 ### Running the App on Docker
 
-First, get the environment up and running with:
+First, you need a `.env` file. If you have a particular need to customize your `.env` you may do so, but for most developers you can just use `.env.example`. Run this in your project root (where you cloned the repo):
+```shell
+cp .env.example .env
 ```
+
+Now get your dev environment up and running by bringing up the docker containers:
+```shell
 docker-compose up
 ```
 
 When the containers are up, you need to create a new MySQL user by logging in the container:
 
-```
+```shell
 docker-compose exec db bash
 ```
 
 Log into MySQL:
 
-```
+```shell
 mysql -u root -p
 ```
 
@@ -34,7 +49,7 @@ The root MySQL password for the `db` container is `password`.
 
 Then, create a new user while granting permissions to the `hacktober` database, and flush privileges:
 
-```
+```mysql
 GRANT ALL ON hacktober.* TO 'hacktober-user'@'%' IDENTIFIED BY 'password';
 FLUSH PRIVILEGES;
 ```
@@ -43,14 +58,14 @@ Exit the MySQL prompt and the container, coming back to your regular shell.
 
 To create the database tables, run migrations inside the container:
 
-```
+```shell
 docker-compose exec app php artisan migrate
 ```
 
 
 To fill the database with sample data, run the `db:seed` command:
 
-```
+```shell
 docker-compose exec app php artisan db:seed
 ```
 
@@ -59,7 +74,7 @@ To import real issues from Github, you'll need to define a Github API Token in t
 
 After setting up the API key, you can import issues with:
 
-```
+```shell
 docker-compose exec app php artisan hacktober:fetch
 ```
 


### PR DESCRIPTION
* Change permissions on `/var/www` in the container so `composer` user can write to the `vendor/` directory.

* Add `zip` and `unzip` to the container dependencies because they are needed by `composer`

* Create `.env` from `.env.example` in the container since `.env` is in the `.dockerignore`

* Remove mount from `docker-compose` because the files are already copied into the image during build and mounting them wipes out all of the build changes.