### PR TITLE
Use the config helper instead of the env helper

### DIFF
--- a/app/Providers/GithubServiceProvider.php
+++ b/app/Providers/GithubServiceProvider.php
@@ -10,7 +10,7 @@ class GithubServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(GithubService::class, function ($app) {
-            return new GithubService(env('GITHUB_API_TOKEN', ''));
+            return new GithubService(config('services.github.token', ''));
         });
     }
 }


### PR DESCRIPTION
It is recommended to use the env helper only in configuration files because after running php artisan config:cache the env file won't be loaded anymore.

https://laravel.com/docs/master/helpers#method-env